### PR TITLE
refactor(Concert): 페이징 기능 구현

### DIFF
--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/controller/ConcertController.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/controller/ConcertController.java
@@ -8,6 +8,7 @@ import com.laydowncoding.tickitecking.global.response.CommonResponse;
 import com.laydowncoding.tickitecking.global.service.UserDetailsImpl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -44,8 +46,11 @@ public class ConcertController {
   }
 
   @GetMapping
-  public ResponseEntity<CommonResponse<List<AllConcertResponseDto>>> getAllConcerts() {
-    List<AllConcertResponseDto> response = concertService.getAllConcerts();
+  public ResponseEntity<CommonResponse<Page<AllConcertResponseDto>>> getAllConcerts(
+      @RequestParam(required = false) int page,
+      @RequestParam(required = false) int size
+  ) {
+    Page<AllConcertResponseDto> response = concertService.getAllConcerts(page, size);
     return CommonResponse.ok(response);
   }
 

--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/repository/ConcertRepositoryImpl.java
@@ -46,7 +46,8 @@ public class ConcertRepositoryImpl extends QuerydslRepositorySupport implements
             .from(concert)
             .join(user).on(concert.companyUserId.eq(user.id))
             .join(auditorium).on(concert.auditoriumId.eq(auditorium.id))
-            .join(image).on(concert.id.eq(image.concertId)));
+            .join(image).on(concert.id.eq(image.concertId))
+            .orderBy(concert.id.desc()));
 
     List<AllConcertResponseDto> responses = query.fetch();
     Long totalCount = query.fetchCount();

--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/repository/ConcertRepositoryImpl.java
@@ -6,36 +6,50 @@ import static com.laydowncoding.tickitecking.domain.image.entity.QImage.image;
 import static com.laydowncoding.tickitecking.domain.user.entity.QUser.user;
 
 import com.laydowncoding.tickitecking.domain.concert.dto.AllConcertResponseDto;
+import com.laydowncoding.tickitecking.domain.concert.entitiy.Concert;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RequiredArgsConstructor
-public class ConcertRepositoryImpl implements ConcertRepositoryQuery {
+public class ConcertRepositoryImpl extends QuerydslRepositorySupport implements
+    ConcertRepositoryQuery {
 
-  private final JPAQueryFactory query;
+  private final JPAQueryFactory queryFactory;
+
+  public ConcertRepositoryImpl(JPAQueryFactory queryFactory) {
+    super(Concert.class);
+    this.queryFactory = queryFactory;
+  }
 
 
   @Override
-  public List<AllConcertResponseDto> getAllConcerts() {
-    return query.select(
-            Projections.constructor(
-                AllConcertResponseDto.class,
-                concert.id,
-                concert.name,
-                image.filePath,
-                concert.startTime,
-                user.nickname,
-                auditorium.name
+  public Page<AllConcertResponseDto> getAllConcerts(Pageable pageable) {
+    JPQLQuery<AllConcertResponseDto> query = getQuerydsl().applyPagination(pageable,
+        queryFactory.select(
+                Projections.constructor(
+                    AllConcertResponseDto.class,
+                    concert.id,
+                    concert.name,
+                    image.filePath,
+                    concert.startTime,
+                    user.nickname,
+                    auditorium.name
+                )
             )
-        )
-        .from(concert)
-        .join(user).on(concert.companyUserId.eq(user.id))
-        .join(auditorium).on(concert.auditoriumId.eq(auditorium.id))
-        .join(image).on(concert.id.eq(image.concertId))
-        .fetch();
+            .from(concert)
+            .join(user).on(concert.companyUserId.eq(user.id))
+            .join(auditorium).on(concert.auditoriumId.eq(auditorium.id))
+            .join(image).on(concert.id.eq(image.concertId)));
+
+    List<AllConcertResponseDto> responses = query.fetch();
+    Long totalCount = query.fetchCount();
+    return new PageImpl<>(responses, pageable, totalCount);
   }
 }

--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/repository/ConcertRepositoryQuery.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/repository/ConcertRepositoryQuery.java
@@ -2,8 +2,10 @@ package com.laydowncoding.tickitecking.domain.concert.repository;
 
 import com.laydowncoding.tickitecking.domain.concert.dto.AllConcertResponseDto;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ConcertRepositoryQuery {
 
-  List<AllConcertResponseDto> getAllConcerts();
+  Page<AllConcertResponseDto> getAllConcerts(Pageable pageable);
 }

--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertService.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertService.java
@@ -4,6 +4,7 @@ import com.laydowncoding.tickitecking.domain.concert.dto.AllConcertResponseDto;
 import com.laydowncoding.tickitecking.domain.concert.dto.ConcertRequestDto;
 import com.laydowncoding.tickitecking.domain.concert.dto.ConcertResponseDto;
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public interface ConcertService {
 
@@ -11,7 +12,7 @@ public interface ConcertService {
 
     ConcertResponseDto getConcert(Long concertId);
 
-    List<AllConcertResponseDto> getAllConcerts();
+    Page<AllConcertResponseDto> getAllConcerts(int page, int size);
 
     ConcertResponseDto updateConcert(Long companyUserId, Long concertId, ConcertRequestDto requestDto);
 

--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceImpl.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,8 +83,9 @@ public class ConcertServiceImpl implements ConcertService {
     }
 
     @Override
-    public List<AllConcertResponseDto> getAllConcerts() {
-        return concertRepository.getAllConcerts();
+    public Page<AllConcertResponseDto> getAllConcerts(int page, int size) {
+        Pageable pageable = PageRequest.of(page-1, size);
+        return concertRepository.getAllConcerts(pageable);
     }
 
     @Override

--- a/src/main/java/com/laydowncoding/tickitecking/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/image/service/ImageServiceImpl.java
@@ -1,9 +1,12 @@
 package com.laydowncoding.tickitecking.domain.image.service;
 
+import static com.laydowncoding.tickitecking.global.exception.errorcode.ConcertErrorCode.NOT_FOUND_CONCERT;
 import static com.laydowncoding.tickitecking.global.exception.errorcode.ImageErrorCode.EMPTY_FILE_EXCEPTION;
 import static com.laydowncoding.tickitecking.global.exception.errorcode.ImageErrorCode.NO_FILE_EXTENSION;
 import static com.laydowncoding.tickitecking.global.exception.errorcode.ImageErrorCode.PUT_OBJECT_EXCEPTION;
 
+import com.laydowncoding.tickitecking.domain.concert.entitiy.Concert;
+import com.laydowncoding.tickitecking.domain.concert.repository.ConcertRepository;
 import com.laydowncoding.tickitecking.domain.image.entity.Image;
 import com.laydowncoding.tickitecking.domain.image.repository.ImageRepository;
 import com.laydowncoding.tickitecking.global.exception.CustomRuntimeException;
@@ -40,6 +43,8 @@ public class ImageServiceImpl implements ImageService {
 
   private final ImageRepository imageRepository;
 
+  private final ConcertRepository concertRepository;
+
   @Override
   @Transactional
   public void upload(MultipartFile imageFile, Long concertId) {
@@ -47,7 +52,11 @@ public class ImageServiceImpl implements ImageService {
       throw new CustomRuntimeException(EMPTY_FILE_EXCEPTION.getMessage());
     }
 
-    Image image = getImage(imageFile, concertId);
+    Concert concert = concertRepository.findById(concertId).orElseThrow(
+        () -> new CustomRuntimeException(NOT_FOUND_CONCERT.getMessage())
+    );
+
+    Image image = getImage(imageFile, concert.getId());
     imageRepository.save(image);
   }
 

--- a/src/test/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceTest.java
+++ b/src/test/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 public class ConcertServiceTest {
@@ -144,7 +147,7 @@ public class ConcertServiceTest {
         given(auditoriumRepository.findById(any())).willReturn(Optional.of(auditorium));
 
         //when
-        List<AllConcertResponseDto> response = concertService.getAllConcerts();
+        Page<AllConcertResponseDto> response = concertService.getAllConcerts(1, 10);
 
         //then
         assertThat(response).hasSize(2);
@@ -157,7 +160,7 @@ public class ConcertServiceTest {
         given(concertRepository.findAll()).willReturn(Collections.emptyList());
 
         //when
-        List<AllConcertResponseDto> response = concertService.getAllConcerts();
+        Page<AllConcertResponseDto> response = concertService.getAllConcerts(1, 10);
 
         //then
         assertThat(response).hasSize(0);


### PR DESCRIPTION
## 📝작업내용
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
조회 성능을 개선시키고자 했습니다.
필요한 컬럼만을 추출하여 조회 성능을 많이 개신시켰지만 페이징 처리를 통해 더 나은 개선이 될 것이라고 생각하여 페이징 처리를 진행하였습니다.
![image](https://github.com/lay-down-coding/tickitecking/assets/67190090/a37820f2-c9e7-4ee8-a92e-a490268acd98)
시간은 10ms 정도 줄어든 것을 확인하였고 더 좋은 개선 방법이 있는지 찾아보았습니다.
방법으로는 첫 1 페이지 요청 시, totalCount를 캐싱하여 2 페이지 이상을 요청했을 때, 캐싱된 totalCount를 통해 속도를 향상시킬 수 있다는 것을 알았습니다. 하지만 이 프로젝트는 첫 페이지가 주요 페이지로 알맞지 않은 방법이라고 생각했습니다.

이후에 콘서트가 시작일이 지났을 때 게시글을 display시켜 주지 않도록 하여 조회 속도를 개선시켜보려고 합니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
✨ 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
