### PR TITLE
refactor(Reservation): 예매시 첫번째 요청만 성공하게 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 **/application.properties
+application-test.properties

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ dependencies {
 
     // S3
     implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.1.0'
+
+    //h2
+    runtimeOnly 'com.h2database:h2'
+
+    //test-slf4j
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/laydowncoding/tickitecking/domain/seat/entity/Seat.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/seat/entity/Seat.java
@@ -80,4 +80,8 @@ public class Seat {
   public void cancel() {
     this.reserved = "N";
   }
+
+  public boolean isReservable() {
+    return this.reserved.equals("N") && this.availability.equals("Y");
+  }
 }

--- a/src/main/java/com/laydowncoding/tickitecking/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/seat/repository/SeatRepository.java
@@ -3,6 +3,7 @@ package com.laydowncoding.tickitecking.domain.seat.repository;
 import com.laydowncoding.tickitecking.domain.seat.entity.Seat;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SeatRepository extends JpaRepository<Seat, Long>, SeatRepositoryQuery {
 
@@ -11,4 +12,8 @@ public interface SeatRepository extends JpaRepository<Seat, Long>, SeatRepositor
   Seat findByConcertIdAndHorizontalAndVertical(Long concertId, String horizontal, String vertical);
 
   List<Seat> findAllByAuditoriumIdAndHorizontalAndVertical(Long auditoriumId, String horizontal, String vertical);
+
+  @Query("select s from Seat s where s.concertId = :concertId "
+      + "and s.horizontal = :horizontal and s.vertical = :vertical ")
+  Seat findSeatForReservation(Long concertId, String horizontal, String vertical);
 }

--- a/src/test/java/com/laydowncoding/tickitecking/domain/reservation/integration/ReservationIntegrationTest.java
+++ b/src/test/java/com/laydowncoding/tickitecking/domain/reservation/integration/ReservationIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.laydowncoding.tickitecking.domain.reservation.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.laydowncoding.tickitecking.domain.reservations.dto.ReservationRequestDto;
+import com.laydowncoding.tickitecking.domain.reservations.repository.ReservationRepository;
+import com.laydowncoding.tickitecking.domain.reservations.service.ReservationService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.context.jdbc.SqlConfig.TransactionMode;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Slf4j
+@Transactional
+@Rollback
+@ActiveProfiles("test")
+public class ReservationIntegrationTest {
+
+    @Autowired
+    ReservationService reservationService;
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
+
+    @DisplayName("동시에 한자리 예매시 첫번째 요청만 예매성공한다.")
+    @Test
+    @Sql(scripts = "/reservation-test-data.sql",
+        config = @SqlConfig(transactionMode = TransactionMode.ISOLATED))
+    void concurrency_test() throws InterruptedException {
+        //given
+        int tryCount = 100;
+        long userId = 1L;
+        Long concertId = 1L;
+        ReservationRequestDto reservationRequestDto = ReservationRequestDto.builder()
+            .horizontal("A")
+            .vertical("0")
+            .build();
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+
+        //when
+        CountDownLatch latch = new CountDownLatch(tryCount);
+        for (int i = 0; i < tryCount; i++) {
+            int finalI = i;
+            executor.submit(() -> {
+                try {
+                    reservationService.createReservation(userId + finalI, concertId,
+                        reservationRequestDto);
+                } catch (Exception e) {
+                    log.error(e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        //then
+        assertThat(reservationRepository.count()).isEqualTo(1);
+    }
+
+    @AfterEach
+    void clearRedis() {
+        redisTemplate.delete("1A0");
+    }
+}

--- a/src/test/resources/reservation-test-data.sql
+++ b/src/test/resources/reservation-test-data.sql
@@ -1,0 +1,9 @@
+insert into auditoriums (created_at, deleted_at, modified_at, address, company_user_id, max_column, max_row, name)
+values (NOW(), null, NOW(), '강남구', 1, '10', 'D', '좋은 공연장');
+
+insert into concerts (created_at, deleted_at, modified_at, auditorium_id, company_user_id, description, name, start_time)
+values (now(), null, now(), 1, 1, '아이유의 콘서트', '아이유 콘서트', now());
+
+insert into seats (auditorium_id, availability, concert_id, grade, horizontal, reserved, vertical)
+values (1, 'Y', 1, 'G', 'A', 'N', '0');
+


### PR DESCRIPTION
## 📝작업내용
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

티켓 예매의 동시성제어를 위해 낙관적락, 비관적락을 적용 후 테스트
성능 면에서 별로 차이가 안나지만 해당 로직에 락을 거는 행위가 db에 많은 부하를 건다고 판단,
현재 로직상 다른 요청은 락을 획득할 필요가 없습니다.(이미 요청이 들어가면 바로 예매가 성공하므로)

->
redis의 setnx를 사용해서 예매 로직에 아래 검증 메서드 추가
```java
    private Boolean isTaken(Long concertId, String horizontal, String vertical) {
        String key = concertId + horizontal + vertical;
        return Boolean.FALSE.equals(
            redisTemplate.opsForValue().setIfAbsent(key, "reserved"));
    }
```
concertId + horizontal+vertical을 키로 하여 해당 키를 가진 다른 요청이 올시 false가 반환되므로 애플리케이션에서 나머지 요청을 예외처리하도록 변경

테스트 결과 단 하나의 쿼리만 생성되고(성공) 나머지는 모두 애플리케이션에어 예외처리됩니다.

자세한 [기록](https://jinkshower.github.io/ticket_reservation_concurrency/) 참고바랍니다.

- 예매 로직 변경에 따라 테스트를 리팩토링했습니다
- 좌석 조회 메서드를 분리했습니다. 다른 메서드로 분리해야 관리하기 쉽다는 생각입니다.
- seat가 예매 가능한지는 seat entity내의 메서드로 옮겼습니다. 다른 조건이 걸릴시 변경점이 하나로 모인다고 판단했습니다.
- 예매 로직 통합테스트를 위해 application-test.properties, 테스트 데이터 sql을 설정했습니다. 해당 부분 테스트 돌릴 필요 있으면 슬랙으로 설정 공유하겠습니다.


## PR 유형
✨ 변경 사항

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
