### PR TITLE
refactor(Concert): 글로벌 캐시 적용

### DIFF
--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceImpl.java
@@ -62,6 +62,7 @@ public class ConcertServiceImpl implements ConcertService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "concerts", key = "#concertId")
     public ConcertResponseDto getConcert(Long concertId) {
         Concert concert = findConcert(concertId);
         List<SeatPriceResponseDto> seatPriceResponseDtos =
@@ -92,7 +93,7 @@ public class ConcertServiceImpl implements ConcertService {
     }
 
     @Override
-    @CacheEvict(value = "concerts", key = "'all'")
+    @CacheEvict(value = "concerts", allEntries = true)
     public ConcertResponseDto updateConcert(Long companyUserId, Long concertId,
         ConcertRequestDto requestDto) {
         Concert concert = findConcert(concertId);
@@ -122,7 +123,7 @@ public class ConcertServiceImpl implements ConcertService {
     }
 
     @Override
-    @CacheEvict(value = "concerts", key = "'all'")
+    @CacheEvict(value = "concerts", allEntries = true)
     public void deleteConcert(Long companyUserId, Long concertId) {
         Concert concert = findConcert(concertId);
         validateCompanyUserId(concert.getCompanyUserId(), companyUserId);

--- a/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceImpl.java
+++ b/src/main/java/com/laydowncoding/tickitecking/domain/concert/service/ConcertServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -93,7 +94,10 @@ public class ConcertServiceImpl implements ConcertService {
     }
 
     @Override
-    @CacheEvict(value = "concerts", allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(value = "concerts", key = "'all'"),
+        @CacheEvict(value = "concerts", key = "#concertId")}
+    )
     public ConcertResponseDto updateConcert(Long companyUserId, Long concertId,
         ConcertRequestDto requestDto) {
         Concert concert = findConcert(concertId);
@@ -123,7 +127,10 @@ public class ConcertServiceImpl implements ConcertService {
     }
 
     @Override
-    @CacheEvict(value = "concerts", allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(value = "concerts", key = "'all'"),
+        @CacheEvict(value = "concerts", key = "#concertId")}
+    )
     public void deleteConcert(Long companyUserId, Long concertId) {
         Concert concert = findConcert(concertId);
         validateCompanyUserId(concert.getCompanyUserId(), companyUserId);


### PR DESCRIPTION
## 📝작업내용
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

1. getConcert메서드에 글로벌 캐시를 적용했습니다. redis에는 concerts::2 라는 키로 들어갑니다.
```
127.0.0.1:6379> get concerts::2
"{\"@class\":\"com.laydowncoding.tickitecking.domain.concert.dto.ConcertResponseDto\",\"id\":2,\"name\":\"name2\",\"description\":\"description2\",\"startTime\":\"2024-04-20 16:26\",\"companyUserId\":2,\"auditoriumId\":2,\"auditoriumName\":\"auditorium2\",\"auditoriumAddress\":\"\xec\x84\x9c\xec\x9a\xb8\",\"auditoriumMaxColumn\":\"10\",\"auditoriumMaxRow\":\"D\",\"seatPrices\":[\"java.util.ImmutableCollections$ListN\",[]]}"
```
2. update, delete시 concerts라는 value의 모든 엔트리를 삭제하도록 변경했습니다. 
update, delete가 일어나는 concertId만 삭제하면 좋을텐데 해당 방법을 아직은 못찾았습니다.

---

-> 2번 부분 수정
@Caching 어노테이션 적용시 @CacheEvict를 여러개 지정할 수 있음을 확인, 적용했습니다.

## PR 유형
✨ 변경 사항

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
